### PR TITLE
Avoid stopping test if uncaught exceptions are thrown

### DIFF
--- a/cypress/e2e/trafficlight/trafficlight.spec.ts
+++ b/cypress/e2e/trafficlight/trafficlight.spec.ts
@@ -67,8 +67,8 @@ function recurse() {
 function runAction(action: string, data: JSONValue): string | undefined {
     switch (action) {
         case 'register':
-            cy.request(data['homeserver_url']['local']).then((response) => {
-                cy.log(response.status);
+            cy.request(`${data['homeserver_url']['local']}/_matrix/client/versions`).then((response) => {
+                cy.log(response.headers);
             });
             cy.visit('/#/register');
             cy.get('.mx_ServerPicker_change', { timeout: 15000 }).click();

--- a/cypress/e2e/trafficlight/trafficlight.spec.ts
+++ b/cypress/e2e/trafficlight/trafficlight.spec.ts
@@ -68,7 +68,7 @@ function runAction(action: string, data: JSONValue): string | undefined {
     switch (action) {
         case 'register':
             cy.request(`${data['homeserver_url']['local']}/_matrix/client/versions`).then((response) => {
-                cy.log(response.headers);
+                cy.log(JSON.stringify(response.headers));
             });
             cy.visit('/#/register');
             cy.get('.mx_ServerPicker_change', { timeout: 15000 }).click();

--- a/cypress/e2e/trafficlight/trafficlight.spec.ts
+++ b/cypress/e2e/trafficlight/trafficlight.spec.ts
@@ -67,6 +67,9 @@ function recurse() {
 function runAction(action: string, data: JSONValue): string | undefined {
     switch (action) {
         case 'register':
+            cy.request(data['homeserver_url']['local']).then((response) => {
+                cy.log(response.status);
+            });
             cy.visit('/#/register');
             cy.get('.mx_ServerPicker_change', { timeout: 15000 }).click();
             cy.get('.mx_ServerPickerDialog_continue').should('be.visible');

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -14,6 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Collect logs and save to disk for upload to trafficlight
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 console.log("Installing logs collector");
 installLogsCollector();
+
+// Don't fail on uncaught exceptions, continue to run (like a client would)
+Cypress.on('uncaught:exception', (err, runnable) => {
+    // returning false here prevents Cypress from
+    // failing the test
+    return false;
+});
+


### PR DESCRIPTION
Unsure whether to merge to main; uncaught exceptions are bad. 
Clients would carry on through, so is it /really/ test-stop-worthy?