### PR TITLE
Raise an exception if you have an unknown action.

### DIFF
--- a/cypress/e2e/trafficlight/trafficlight.spec.ts
+++ b/cypress/e2e/trafficlight/trafficlight.spec.ts
@@ -295,7 +295,6 @@ function runAction(action: string, data: JSONValue): string | undefined {
             cy.log('Client asked to exit, test complete or server teardown');
             return;
         default:
-            cy.log('WARNING: unknown action ', action);
-            return;
+            throw new Error('WARNING: unknown action ', action);
     }
 }

--- a/cypress/e2e/trafficlight/trafficlight.spec.ts
+++ b/cypress/e2e/trafficlight/trafficlight.spec.ts
@@ -295,6 +295,6 @@ function runAction(action: string, data: JSONValue): string | undefined {
             cy.log('Client asked to exit, test complete or server teardown');
             return;
         default:
-            throw new Error('WARNING: unknown action ', action);
+            throw new Error(`WARNING: unknown action "${action}"`);
     }
 }


### PR DESCRIPTION
This was used to generate exceptions in the client code, that were then passed back to the trafficlight code to help test matrix-org/trafficlight#63

We should keep it so that we can see in the UI if there's an issue in the adapter code.